### PR TITLE
Add check for Windows environment when launching Meteor.

### DIFF
--- a/gulp/jobs/meteor.js
+++ b/gulp/jobs/meteor.js
@@ -5,7 +5,8 @@ var _ = require('lodash');
 
 function runMeteor(inDir, environmentVariables) {
     var env = _.extend(environmentVariables, process.env);
-    return exec("meteor", [], {tag: "Meteor run.", options: {cwd: inDir, env: env}});
+    var meteor = (process.platform === "win32" ? "meteor.bat" : "meteor");
+    return exec(meteor, [], {tag: "Meteor run.", options: {cwd: inDir, env: env}});
 };
 
 module.exports = runMeteor;


### PR DESCRIPTION
Ran into an issue when running this on my Windows machine. 

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: spawn ENOENT
    at errnoException (child_process.js:1011:11)
    at Process.ChildProcess._handle.onexit (child_process.js:802:34)
```

Turns out that "child_process.spawn()" couldn't find the meteor batch script. The link below describes the basic issue more clearly.

http://stackoverflow.com/a/17537559
