### PR TITLE
fixed tslint exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea/

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "gulp-exit": "0.0.2",
     "gulp-tsc": "^0.9.2",
     "gulp-tslint": "^1.5.0",
-    "gulp-util": "~2.2.19",
+    "gulp-util": "~3.0.5",
     "run-sequence": "^0.3.6",
-    "typescript": "^1.5.0-alpha",
-    "lodash": "3.2.0"
+    "typescript": "^1.5.0-beta",
+    "lodash": "3.9.3"
   }
 }

--- a/src/.meteor/versions
+++ b/src/.meteor/versions
@@ -6,7 +6,7 @@ blaze-tools@1.0.3
 boilerplate-generator@1.0.3
 callback-hook@1.0.3
 check@1.0.5
-dataflows:typescript-utils@0.1.4
+dataflows:typescript-utils@0.1.5
 ddp@1.1.0
 deps@1.0.7
 ejson@1.0.6
@@ -16,10 +16,14 @@ html-tools@1.0.4
 htmljs@1.0.4
 http@1.1.0
 id-map@1.0.3
-iron:core@0.3.4
-iron:dynamic-template@0.4.1
-iron:layout@0.4.1
-iron:router@0.9.4
+iron:controller@1.0.7
+iron:core@1.0.7
+iron:dynamic-template@1.0.7
+iron:layout@1.0.7
+iron:location@1.0.7
+iron:middleware-stack@1.0.7
+iron:router@1.0.7
+iron:url@1.0.7
 jquery@1.11.3_2
 json@1.0.3
 launch-screen@1.0.2
@@ -42,7 +46,6 @@ routepolicy@1.0.5
 session@1.1.0
 spacebars@1.0.6
 spacebars-compiler@1.0.6
-stevezhu:lodash@3.7.0
 templating@1.1.1
 tracker@1.0.7
 ui@1.0.6

--- a/src/server/ClicksMethodsImpl.ts
+++ b/src/server/ClicksMethodsImpl.ts
@@ -12,7 +12,7 @@ module sampleapp.model {
             ClicksCollection.insert({
                 name: args.name,
                 time: new Date()
-            })
+            });
         }
     }
     MeteorMethod.register(SaveClick, new SaveClickImpl());

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -10,5 +10,4 @@ module sampleapp.router {
 
     export interface ISingleClickRouteParams { clickId: string; }
     Router.route("SingleClick", { path: "/click/:clickId", controller: "SingleClickController" });
-    
 }


### PR DESCRIPTION
Two minor tslint errors fixed.  Also added .idea to .gitignore for WebStorm users

``` bash
(no-trailing-whitespace) shared/routes.ts[13, 1]: trailing whitespace
[11:58:25] 'tslint' errored after 480 ms
[11:58:25] Error in plugin 'gulp-tslint'
Message:
    Failed to lint: shared/routes.ts[13, 1]: trailing whitespace.
```

``` bash
(no-trailing-comma) server/ClicksMethodsImpl.ts[14, 33]: trailing comma
(semicolon) server/ClicksMethodsImpl.ts[15, 15]: missing semicolon
[11:48:46] 'tslint' errored after 434 ms
[11:48:46] Error in plugin 'gulp-tslint'
Message:
    Failed to lint: server/ClicksMethodsImpl.ts[14, 33]: trailing comma, server/ClicksMethodsImpl.ts[15, 15]: missing semicolon.
```
